### PR TITLE
Update Python versions in workflow configuration

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.13", "3.14", "3.15"]
+        python-version: ["3.13", "3.14"] # , "3.15"]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Removed Python version 3.15 from the CI matrix.