### PR TITLE
Refactor startup logging and update server settings

### DIFF
--- a/cremalink/local_server.py
+++ b/cremalink/local_server.py
@@ -7,10 +7,11 @@ coffee machine on the local network. It exposes a simple HTTP API that the
 communication, including authentication and command formatting.
 
 This script can be run directly from the command line, for example:
-`cremalink-server --ip 127.0.0.1 --port 10280`
+`cremalink-server --ip 0.0.0.0 --port 10280`
 """
 import argparse
 import sys
+from logging import Logger
 
 import uvicorn
 
@@ -28,13 +29,12 @@ class LocalServer:
             settings: A `ServerSettings` object containing configuration like
                       host and port.
         """
+        self.logger = None
         self.settings = settings
         self.app = create_app(settings=self.settings)
 
     def start(self) -> None:
         """Starts the Uvicorn server to serve the application."""
-        print(f"Starting cremalink local server on http://{self.settings.server_ip}:{self.settings.server_port}...")
-        print(f"IP address advertised to the coffee machine: {self.settings.advertised_ip}")
         uvicorn.run(
             self.app,
             host=self.settings.server_ip,
@@ -79,7 +79,7 @@ def main():
         sys.exit(0)
 
     args = parser.parse_args()
-    settings = ServerSettings(server_settings_path=args.settings_path, server_ip=args.ip, server_port=args.port)
+    settings = ServerSettings(server_settings_path=args.settings_path, server_ip=args.ip, server_port=args.port, advertised_ip=args.advertised_ip)
     server = LocalServer(settings)
     server.start()
 

--- a/cremalink/local_server_app/api.py
+++ b/cremalink/local_server_app/api.py
@@ -58,6 +58,9 @@ def create_app(
     stop_event = asyncio.Event()
     jobs = JobManager()
 
+    print(f"Starting cremalink local server on http://{settings.server_ip}:{settings.server_port}...")
+    print(f"IP address advertised to the coffee machine: {settings.advertised_ip}")
+
     # Define the application lifespan context manager for startup/shutdown events.
     @asynccontextmanager
     async def lifespan(app_: FastAPI) -> AsyncIterator[None]:


### PR DESCRIPTION
Moved startup print statements to `create_app` and updated `LocalServer` to pass the `advertised_ip` argument to `ServerSettings`. Also updated the docstring example IP address.