### PR TITLE
Update documentation and local server usage details

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Cremalink provides a unified interface to interact with smart coffee machines vi
 > [!TIP]
 > For detailed guides, advanced configuration, and developer deep-dives, please visit our **[Project Wiki](https://github.com/miditkl/cremalink/wiki)**.
 
+> [!NOTE] 
+> This project was developed with a result-oriented approach, primarily optimized for the De'Longhi PrimaDonna Soul. While the architecture is designed to be extensible, some logic may currently be tightly coupled to this specific model and might not work seamlessly with others yet.
+>The goal is to make the library fully generic. If you notice parts that are too specific to the PrimaDonna Soul or encounter issues with other machines, we highly encourage contributions! Refactoring and generalizations are very welcome to improve support for a wider range of devices.
+
 ---
 
 ## 🚀 Installation
@@ -47,16 +51,16 @@ pip install "cremalink[test]"  # For running pytest suites
 Cremalink includes a FastAPI-based server for headless environments:
 
 ```bash
-# Start the server (default port 10800)
-cremalink-server --ip 0.0.0.0 --port 10800
+# Start the server
+cremalink-server --ip 0.0.0.0 --port 10280 --settings_path "conf.json"
 ```
 > More information: [Local Server Setup](https://github.com/miditkl/cremalink/wiki/3.-Local-Server-Setup)
 
 ### Python API (Local Control)
 
-Connect to your machine directly via your local network for the lowest latency
+Connect to your machine directly via your local network for the lowest latency.
 
-> More information: [Local Device]()
+> More information: [Local Device Usage](https://github.com/miditkl/cremalink/wiki/4.-Local-Device-Usage)
 
 ---
 

--- a/cremalink/local_server.py
+++ b/cremalink/local_server.py
@@ -6,8 +6,11 @@ coffee machine on the local network. It exposes a simple HTTP API that the
 `LocalTransport` can use, and it handles the complexities of direct device
 communication, including authentication and command formatting.
 
-This script can be run directly from the command line, for example:
-`cremalink-server --ip 0.0.0.0 --port 10280`
+This script can be run directly from the command line. It requires a settings
+file for device credentials and can be configured with a specific IP and port.
+
+Example:
+`cremalink-server --settings_path /path/to/your/conf.json --ip 0.0.0.0 --port 10280`
 """
 import argparse
 import sys
@@ -64,13 +67,13 @@ def main():
         "--advertised_ip",
         type=str,
         default=None,
-        help="IP address to advertise to the coffee machine."
+        help="IP address to advertise to the coffee machine. If not set, the server's IP is used."
     )
     parser.add_argument(
         "--settings_path",
         type=str,
         default="",
-        help="Path to the configuration file, with device credentials."
+        help="Path to the JSON configuration file containing device credentials (DSN, LAN key, etc.)."
     )
 
     # Manually handle --help to avoid argument parsing errors with unknown args.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,32 +24,24 @@
 Cremalink provides a unified interface to interact with smart coffee machines via **Local LAN control** or **Cloud API**. It allows for real-time state monitoring and precise command execution.
 
 .. tip::
-
    For detailed guides, advanced configuration, and developer deep-dives, please visit our `Project Wiki <https://github.com/miditkl/cremalink/wiki>`_.
 
-API Reference
-=============
-
-.. toctree::
-   :maxdepth: 2
-   :caption: Contents:
-
-   api/modules
-
+.. note::
+   This project was developed with a result-oriented approach, primarily optimized for the De'Longhi PrimaDonna Soul. While the architecture is designed to be extensible, some logic may currently be tightly coupled to this specific model and might not work seamlessly with others yet.
+   The goal is to make the library fully generic. If you notice parts that are too specific to the PrimaDonna Soul or encounter issues with other machines, we highly encourage contributions! Refactoring and generalizations are very welcome to improve support for a wider range of devices.
 
 ----
 
 🚀 Installation
 --------------
 
-Install the package via ``pip`` (Cremalink requires **Python 3.13+**):
+Install the package via `pip` (Cremalink requires **Python 3.13+**):
 
 .. code-block:: bash
 
    pip install cremalink
 
-Optional Dependencies
-~~~~~~~~~~~~~~~~~~~~~
+**Optional Dependencies**
 
 To include tools for development or testing:
 
@@ -63,15 +55,14 @@ To include tools for development or testing:
 🛠 Usage
 -------
 
-Integrated API Server
-~~~~~~~~~~~~~~~~~~~~~
+**Integrated API Server**
 
 Cremalink includes a FastAPI-based server for headless environments:
 
 .. code-block:: bash
 
-   # Start the server (default port 10800)
-   cremalink-server --ip 0.0.0.0 --port 10800
+   # Start the server
+   cremalink-server --ip 0.0.0.0 --port 10280 --settings_path "conf.json"
 
 More information: `Local Server Setup <https://github.com/miditkl/cremalink/wiki/3.-Local-Server-Setup>`_
 
@@ -80,28 +71,28 @@ Python API (Local Control)
 
 Connect to your machine directly via your local network for the lowest latency.
 
+More information: `Local Device Usage <https://github.com/miditkl/cremalink/wiki/4.-Local-Device-Usage>`_
+
 ----
 
 🛠 Development
 -------------
 
-Testing
-~~~~~~~
+**Testing**
 
-Run the comprehensive test suite using ``pytest``:
+Run the comprehensive test suite using `pytest`:
 
 .. code-block:: bash
 
    pytest tests/
 
-Contributing
-~~~~~~~~~~~~
+**Contributing**
 
-Contributions are welcome! If you have a machine profile not yet supported, please check the `Wiki: 5. Adding Custom Devices <https://github.com/miditkl/cremalink/wiki/5.-Adding-Custom-Devices>`_ on how to add new ``.json`` device definitions.
+Contributions are welcome! If you have a machine profile not yet supported, please check the `Wiki: 5. Adding Custom Devices <https://github.com/miditkl/cremalink/wiki/5.-Adding-Custom-Devices>`_ on how to add new `.json` device definitions.
 
 Currently supported devices:
 
-- ``De'Longhi PrimaDonna Soul (AY008ESP1)``
+* De'Longhi PrimaDonna Soul (AY008ESP1)
 
 ----
 
@@ -112,4 +103,21 @@ Distributed under the **AGPL-3.0-or-later** License. See `LICENSE <https://githu
 
 ----
 
-*Developed by* `Midian Tekle Elfu <mailto:developer@midian.tekleelfu.de>`_. *Supported by the community.*
+Developed by `Midian Tekle Elfu <mailto:developer@midian.tekleelfu.de>`_. Supported by the community.
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+   :hidden:
+
+   Home <self>
+   modules
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API Reference
+   :hidden:
+
+   api/cremalink


### PR DESCRIPTION
- Add note on device specificity (PrimaDonna Soul) and contribution goals to README and docs.
- Update `cremalink-server` command examples to include `--settings_path` and use port 10280.
- Refine CLI help text and docstrings in `local_server.py`.
- Restructure `index.rst` layout and fix links in README.