### PR TITLE
Handle HTTP errors when fetching LAN key in CloudTransport

### DIFF
--- a/cremalink/transports/cloud/transport.py
+++ b/cremalink/transports/cloud/transport.py
@@ -55,8 +55,11 @@ class CloudTransport(DeviceTransport):
         self.ip = device.get("lan_ip")
 
         # Fetch LAN key, which might be needed for other operations.
-        lan = self._get("/lan.json") or {}
-        self.lan_key = lan.get("lanip", {}).get("lanip_key")
+        try:
+            lan = self._get("/lan.json") or {}
+            self.lan_key = lan.get("lanip", {}).get("lanip_key")
+        except requests.HTTPError:
+            self.lan_key = None
 
     def configure(self) -> None:
         """Configuration is handled during __init__, so this is a no-op."""


### PR DESCRIPTION
Wrap the LAN key retrieval in a try-except block to prevent initialization failures if the endpoint returns an error.