### PR TITLE
Remove hardcoded property defaults and persist data request property

### DIFF
--- a/cremalink/local_server_app/state.py
+++ b/cremalink/local_server_app/state.py
@@ -149,9 +149,9 @@ class LocalServerState:
             self.last_properties_received_at = None
             self._properties_request_pending = False
         self.logger.info("configured", extra={"details": {"dsn": dsn, "device_ip": device_ip, "scheme": device_scheme}})
-        await self._save_server_settings(dsn=self.dsn, device_ip=self.device_ip, lan_key=self.lan_key, device_scheme=self.device_scheme, monitor_property_name=self.monitor_property_name)
+        await self._save_server_settings(dsn=self.dsn, device_ip=self.device_ip, lan_key=self.lan_key, device_scheme=self.device_scheme, monitor_property_name=self.monitor_property_name, data_request_property_name=self.data_request_property_name)
 
-    async def _save_server_settings(self, dsn: str, device_ip: str, lan_key: str, device_scheme: str, monitor_property_name: str):
+    async def _save_server_settings(self, dsn: str, device_ip: str, lan_key: str, device_scheme: str, monitor_property_name: str, data_request_property_name: str):
         if self.settings.server_settings_path == "":
             return
         data = {
@@ -159,7 +159,8 @@ class LocalServerState:
             "device_ip": device_ip,
             "lan_key": lan_key,
             "device_scheme": device_scheme,
-            "monitor_property_name": monitor_property_name
+            "monitor_property_name": monitor_property_name,
+            "data_request_property_name": data_request_property_name
         }
         try:
             with open(self.settings.server_settings_path, "w") as f:

--- a/cremalink/transports/cloud/transport.py
+++ b/cremalink/transports/cloud/transport.py
@@ -111,7 +111,7 @@ class CloudTransport(DeviceTransport):
     def send_command(self, command: str, alternative_property: str = None) -> Any:
         """Sends a command to the device by creating a new 'datapoint' via the cloud API."""
         payload = {"datapoint": {"value": command}}
-        data_request = alternative_property or self.property_map.get('data_request', 'data_request')
+        data_request = alternative_property or self.property_map.get("data_request")
         return self._post(path=f"/properties/{data_request}/datapoints.json", data=payload)
 
     def set_mappings(self, command_map: dict[str, Any], property_map: dict[str, Any]) -> None:
@@ -138,7 +138,7 @@ class CloudTransport(DeviceTransport):
         This works by fetching the specific 'monitor' property, extracting its
         base64 value, and then decoding it into a structured snapshot.
         """
-        property_name = self.property_map.get("monitor", "d302_monitor")
+        property_name = self.property_map.get("monitor")
         prop = self.get_property(property_name) or {}
         raw_b64 = prop.get("value")
         received_at = prop.get("updated_at")

--- a/cremalink/transports/local/transport.py
+++ b/cremalink/transports/local/transport.py
@@ -83,13 +83,15 @@ class LocalTransport(DeviceTransport):
         Configures the local proxy server with the device's connection details.
         This must be called before other methods can be used.
         """
-        monitor_prop_name = self.property_map.get("monitor", "d302_monitor")
+        monitor_prop_name = self.property_map.get("monitor")
+        data_request_prop_name = self.property_map.get("data_request")
         payload = {
             "dsn": self.dsn,
             "device_ip": self.device_ip,
             "lan_key": self.lan_key,
             "device_scheme": self.device_scheme,
             "monitor_property_name": monitor_prop_name,
+            "data_request_property_name": data_request_prop_name
         }
         try:
             resp = self._post_server("/configure", payload)
@@ -156,9 +158,11 @@ class LocalTransport(DeviceTransport):
         Sets the command and property maps and re-configures the server if needed.
         If the name of the monitoring property changes, the server is reconfigured.
         """
-        previous_monitor = self.property_map.get("monitor", "d302_monitor")
+        previous_monitor = self.property_map.get("monitor")
+        previous_data_request = self.property_map.get("data_request")
         self.command_map = command_map
         self.property_map = property_map
-        updated_monitor = self.property_map.get("monitor", "d302_monitor")
-        if self._auto_configure and (not self._configured or previous_monitor != updated_monitor):
+        updated_monitor = self.property_map.get("monitor")
+        updated_data_request = self.property_map.get("data_request")
+        if self._auto_configure and (not self._configured or previous_monitor != updated_monitor or previous_data_request != updated_data_request):
             self.configure()


### PR DESCRIPTION
- Remove default values for 'monitor' and 'data_request' properties in LocalTransport and CloudTransport to rely on device mappings.
- Update LocalTransport to include 'data_request_property_name' in the server configuration payload.
- Update LocalServerState to save 'data_request_property_name' in server settings.

