### PR TITLE
Update dependency constraints and bump pytest version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,9 @@ dependencies = [
     "fastapi==0.135.3",
     "uvicorn==0.44.0",
     "httpx==0.28.1",
-    "pydantic==2.12.5",
-    "pydantic-settings==2.13.1",
-    "starlette==0.52.1",
+    "pydantic>=2.12.0",
+    "pydantic-settings>=2.13.0",
+    "starlette>=0.52.0, <1.0.0",
 ]
 license = "AGPL-3.0-or-later"
 license-files = ["LICENSE"]
@@ -46,11 +46,11 @@ classifiers = [
 dev = [
     "cremalink[test]",
     "cremalink[docs]",
-    "ipykernel==7.2.0",
-    "notebook==7.5.5",
+    "ipykernel>=7.2.0",
+    "notebook>=7.5.5",
 ]
 test = [
-    "pytest==9.0.2",
+    "pytest>=9.0.3",
     "pytest-asyncio==1.3.0",
 ]
 docs = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,10 @@ pycryptodome==3.23.0
 fastapi==0.135.3
 uvicorn==0.44.0
 httpx==0.28.1
-pydantic==2.12.5
-pydantic-settings==2.13.1
-notebook==7.5.5
-ipykernel==7.2.0
-pytest==9.0.2
-pytest-asyncio==1.3.0
-starlette==0.52.1
+pydantic>=2.12.0
+pydantic-settings>=2.13.0
+notebook>=7.5.5
+ipykernel>=7.2.0
+pytest>=9.0.3
+pytest-asyncio>=1.3.0
+starlette>=0.52.0, <1.0.0

--- a/uv.lock
+++ b/uv.lock
@@ -348,18 +348,18 @@ requires-dist = [
     { name = "cremalink", extras = ["test"], marker = "extra == 'dev'" },
     { name = "fastapi", specifier = "==0.135.3" },
     { name = "httpx", specifier = "==0.28.1" },
-    { name = "ipykernel", marker = "extra == 'dev'", specifier = "==7.2.0" },
-    { name = "notebook", marker = "extra == 'dev'", specifier = "==7.5.5" },
+    { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=7.2.0" },
+    { name = "notebook", marker = "extra == 'dev'", specifier = ">=7.5.5" },
     { name = "pycryptodome", specifier = "==3.23.0" },
-    { name = "pydantic", specifier = "==2.12.5" },
-    { name = "pydantic-settings", specifier = "==2.13.1" },
-    { name = "pytest", marker = "extra == 'test'", specifier = "==9.0.2" },
+    { name = "pydantic", specifier = ">=2.12.0" },
+    { name = "pydantic-settings", specifier = ">=2.13.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = "==1.3.0" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = "==9.1.0" },
     { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = "==3.1.0" },
     { name = "sphinxcontrib-websupport", marker = "extra == 'docs'", specifier = "==2.0.0" },
-    { name = "starlette", specifier = "==0.52.1" },
+    { name = "starlette", specifier = ">=0.52.0,<1.0.0" },
     { name = "uvicorn", specifier = "==0.44.0" },
 ]
 provides-extras = ["dev", "test", "docs"]
@@ -1256,7 +1256,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1265,9 +1265,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Modified `pyproject.toml` and `requirements.txt` to use flexible version specifiers (`>=`) instead of exact matches (`==`) for `pydantic`, `pydantic-settings`, `starlette`, `ipykernel`, `notebook`, and `pytest`. Additionally, bumped the minimum `pytest` version to `9.0.3` and updated `uv.lock` accordingly.