### PR TITLE
Add cloud authentication flow and move user agents to config

### DIFF
--- a/cremalink/clients/auth.py
+++ b/cremalink/clients/auth.py
@@ -1,0 +1,238 @@
+import base64
+import json
+import os
+import requests
+import urllib.parse
+from datetime import datetime
+
+from cremalink.resources.api_config import load_api_config
+from cremalink.resources.lang import load_lang_config
+
+class CloudToken:
+    """
+    Responsible for handling authentication with the Ayla IoT cloud platform.
+    This module implements the multi-step authentication flow required to obtain a refresh token, which can be used for API interactions.
+    """
+    def __init__(self, refresh_token: str):
+        self.refresh_token = refresh_token
+
+    """
+    Saves the refresh token to a JSON file at the specified path. The file will contain a single key "refresh_token" with the token value. If the file already exists, it will be overwritten.
+    
+    Args:
+        path (str): The file path where the token should be saved. Defaults to "token.json".
+    
+    Returns:
+        str: The absolute path to the saved token file.
+    """
+    def save(self, path: str = "token.json") -> str:
+        abs_path = os.path.abspath(path)
+        with open(abs_path, "w", encoding="utf-8") as f:
+            json.dump({"refresh_token": self.refresh_token}, f, indent=2)
+        return abs_path
+
+    """
+    Returns a string representation of the CloudToken instance, which is the refresh token itself. This allows for easy printing or logging of the token value when the instance is converted to a string.
+    
+    Returns:
+        str: The refresh token contained in the CloudToken instance.
+    """
+    def __str__(self):
+        return self.refresh_token
+
+
+def _get_query_param(url: str, param: str):
+    query = urllib.parse.urlparse(url).query
+    params = urllib.parse.parse_qs(query)
+    return params.get(param, [None])[0]
+
+
+def authenticate_cloud(email: str, password: str, language: str = "en") -> CloudToken:
+    """
+    Performs the multi-step authentication flow to obtain a refresh token for the Ayla IoT cloud platform.
+
+    This function executes the following steps:
+    1. Authorize: Initiates the authorization process to obtain a context parameter.
+    2. Get IDs: Retrieves necessary IDs (ucid, gmid, gmid_ticket) for the login process.
+    3. Login: Authenticates the user with their email and password, along with risk context information, to obtain a login token.
+    4. Get User Info: Fetches user information using the login token to obtain UID, UIDSignature, and signatureTimestamp.
+    5. Consent: Simulates the user consent process to obtain a signature for the authorization continue step.
+    6. Authorization Continue: Continues the authorization process using the context, login token, and consent signature to obtain an authorization code.
+    7. IDP Token: Exchanges the authorization code for an IDP token.
+    8. Exchange for Ayla: Uses the IDP token to sign in to the Ayla cloud and obtain a refresh token.
+
+    Args:
+        email (str): The user's email address for authentication.
+        password (str): The user's password for authentication.
+        language (str): The preferred language for the authentication process (default is "en").
+
+    Returns:
+        CloudToken: An instance of CloudToken containing the obtained refresh token.
+    """
+
+    api_conf = load_api_config()
+    gigya_key = api_conf["GIGYA"]["API_KEY"]
+    client_id = api_conf["GIGYA"]["CLIENT_ID"]
+    client_secret = api_conf["GIGYA"]["CLIENT_SECRET"]
+    sdk_build = api_conf["GIGYA"]["SDK_BUILD"]
+    app_id = api_conf["AYLA"]["APP_ID"]
+    app_secret = api_conf["AYLA"]["APP_SECRET"]
+
+    browser_agent = api_conf["USER_AGENT"]["BROWSER"]
+    token_agent = api_conf["USER_AGENT"]["TOKEN"]
+
+    auth_header = "Basic " + base64.b64encode(f"{client_id}:{client_secret}".encode()).decode()
+
+    lang_conf = load_lang_config()
+    supported_langs = lang_conf.get("languages", {})
+    if language not in supported_langs:
+        language = "en"
+
+    # Step 1: Authorize
+    res = requests.get(
+        f"https://fidm.eu1.gigya.com/oidc/op/v1.0/{gigya_key}/authorize",
+        headers={"User-Agent": browser_agent},
+        params={
+            "client_id": client_id,
+            "response_type": "code",
+            "redirect_uri": "https://google.it",
+            "scope": "openid email profile UID comfort en alexa",
+            "nonce": str(int(datetime.now().timestamp())),
+        },
+        allow_redirects=False,
+    )
+    context = _get_query_param(res.headers.get("Location", ""), "context")
+
+    # Step 2: Get IDs
+    res = requests.get(
+        "https://socialize.eu1.gigya.com/socialize.getIDs",
+        headers={"User-Agent": browser_agent},
+        params={
+            "APIKey": gigya_key,
+            "includeTicket": True,
+            "pageURL": "https://aylaopenid.delonghigroup.com/",
+            "sdk": "js_latest",
+            "sdkBuild": sdk_build,
+            "format": "json",
+        },
+    ).json()
+    ucid = res.get("ucid")
+    gmid = res.get("gmid")
+    gmid_ticket = res.get("gmidTicket")
+
+    # Step 3: Login
+    risk_context_json = json.dumps({
+        "b0": 4494, "b1": [0, 2, 2, 0], "b2": 2, "b3": [], "b4": 2, "b5": 1,
+        "b6": browser_agent,
+        "b7": [{"name": "PDF Viewer", "filename": "internal-pdf-viewer", "length": 2}],
+        "b8": datetime.now().strftime("%H:%M:%S"),
+        "b9": 0, "b10": {"state": "denied"}, "b11": False,
+        "b13": [5, "440|956|24", False, True],
+    })
+
+    res = requests.post(
+        "https://accounts.eu1.gigya.com/accounts.login",
+        headers={"User-Agent": browser_agent},
+        data={
+            "loginID": email,
+            "password": password,
+            "sessionExpiration": 7884009,
+            "targetEnv": "jssdk",
+            "include": "profile,data,emails,subscriptions,preferences",
+            "includeUserInfo": True,
+            "loginMode": "standard",
+            "lang": language,
+            "riskContext": urllib.parse.quote(risk_context_json),
+            "APIKey": gigya_key,
+            "source": "showScreenSet",
+            "sdk": "js_latest",
+            "authMode": "cookie",
+            "pageURL": "https://aylaopenid.delonghigroup.com/",
+            "gmid": gmid,
+            "ucid": ucid,
+            "sdkBuild": sdk_build,
+            "format": "json",
+        },
+    ).json()
+
+    if "sessionInfo" not in res:
+        raise ValueError(f"Gigya Login failed: {res}")
+
+    login_token = res["sessionInfo"]["login_token"]
+
+    # Step 4: Get User Info
+    res = requests.post(
+        "https://socialize.eu1.gigya.com/socialize.getUserInfo",
+        headers={"User-Agent": browser_agent},
+        data={
+            "enabledProviders": "*",
+            "APIKey": gigya_key,
+            "sdk": "js_latest",
+            "login_token": login_token,
+            "authMode": "cookie",
+            "pageURL": "https://aylaopenid.delonghigroup.com/",
+            "gmid": gmid,
+            "ucid": ucid,
+            "sdkBuild": sdk_build,
+            "format": "json",
+        },
+    ).json()
+    user_uid = res["UID"]
+    user_uid_sig = res["UIDSignature"]
+    user_sig_ts = res["signatureTimestamp"]
+
+    # Step 5: Consent
+    res = requests.get(
+        "https://aylaopenid.delonghigroup.com/OIDCConsentPage.php",
+        headers={"User-Agent": browser_agent},
+        params={
+            "lang": language,
+            "context": context,
+            "clientID": client_id,
+            "scope": "openid+email+profile+UID+comfort+en+alexa",
+            "UID": user_uid,
+            "UIDSignature": user_uid_sig,
+            "signatureTimestamp": user_sig_ts,
+        },
+    ).text
+    signature = res.split("const consentObj2Sig = '")[1].split("';")[0]
+
+    # Step 6: Authorization Continue
+    res = requests.get(
+        f"https://fidm.eu1.gigya.com/oidc/op/v1.0/{gigya_key}/authorize/continue",
+        headers={"User-Agent": browser_agent},
+        params={
+            "context": context,
+            "login_token": login_token,
+            "consent": json.dumps(
+                {"scope": "openid email profile UID comfort en alexa", "clientID": client_id, "context": context,
+                 "UID": user_uid, "consent": True},
+                separators=(",", ":")
+            ),
+            "sig": signature,
+            "gmidTicket": gmid_ticket,
+        },
+        allow_redirects=False,
+    )
+    code = _get_query_param(res.headers.get("Location", ""), "code")
+
+    # Step 7: IDP Token
+    res = requests.post(
+        f"https://fidm.eu1.gigya.com/oidc/op/v1.0/{gigya_key}/token",
+        headers={
+            "User-Agent": token_agent,
+            "Authorization": auth_header,
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        data={"code": code, "grant_type": "authorization_code", "redirect_uri": "https://google.it"},
+    ).json()
+    idp_token = res["access_token"]
+
+    # Step 8: Exchange for Ayla
+    res = requests.post(
+        "https://user-field-eu.aylanetworks.com/api/v1/token_sign_in",
+        headers={"User-Agent": token_agent},
+        data={"app_id": app_id, "app_secret": app_secret, "token": idp_token},
+    ).json()
+
+    return CloudToken(res["refresh_token"])

--- a/cremalink/clients/cloud.py
+++ b/cremalink/clients/cloud.py
@@ -5,19 +5,15 @@ import os
 
 import requests
 
+from cremalink import Device
 from cremalink.domain import create_cloud_device
 from cremalink.resources import load_api_config
-
-API_USER_AGENT = "datatransport/3.1.2 android/"
-TOKEN_USER_AGENT = "DeLonghiComfort/3 CFNetwork/1568.300.101 Darwin/24.2.0"
-
 
 class Client:
     """
     Client for interacting with the Ayla IoT cloud platform.
     Manages authentication (access and refresh tokens) and device discovery.
     """
-
     def __init__(self, token_path: str):
         # Ensure the token_path points to a JSON file.
         if not token_path.endswith(".json"):
@@ -28,6 +24,9 @@ class Client:
         self.gigya_api = self.api_conf.get("GIGYA")
         self.ayla_api = self.api_conf.get("AYLA")
 
+        self.token_agent = self.api_conf["USER_AGENT"]["TOKEN"]
+        self.api_agent = self.api_conf["USER_AGENT"]["API"]
+
         self.token_path = token_path
         # Retrieve or refresh the access token upon initialization.
         self.access_token = self.__get_access_token()
@@ -35,7 +34,7 @@ class Client:
         self.devices = requests.get(
             url=f"{self.ayla_api.get('API_URL')}/devices.json",
             headers={
-                "User-Agent": API_USER_AGENT,
+                "User-Agent": self.api_agent,
                 "Authorization": f"auth_token {self.access_token}",
                 "Accept": "application/json",
             },
@@ -53,7 +52,7 @@ class Client:
             devices.append(device["device"]["dsn"])
         return devices
 
-    def get_device(self, dsn: str, device_map_path: dict | None = None):
+    def get_device(self, dsn: str, device_map_path: dict | None = None) -> Device | None:
         """
         Retrieves a specific cloud device by its DSN.
 
@@ -81,7 +80,7 @@ class Client:
         response = requests.post(
             url=f"{self.ayla_api.get('OAUTH_URL')}/users/refresh_token.json",
             headers={
-                "User-Agent": TOKEN_USER_AGENT,
+                "User-Agent": self.token_agent,
                 "Content-Type": "application/json",
             },
             json={"user": {"refresh_token": refresh_token}},

--- a/cremalink/clients/cloud.py
+++ b/cremalink/clients/cloud.py
@@ -5,7 +5,6 @@ import os
 
 import requests
 
-from cremalink import Device
 from cremalink.domain import create_cloud_device
 from cremalink.resources import load_api_config
 
@@ -52,7 +51,7 @@ class Client:
             devices.append(device["device"]["dsn"])
         return devices
 
-    def get_device(self, dsn: str, device_map_path: dict | None = None) -> Device | None:
+    def get_device(self, dsn: str, device_map_path: dict | None = None):
         """
         Retrieves a specific cloud device by its DSN.
 

--- a/cremalink/resources/api_config.json
+++ b/cremalink/resources/api_config.json
@@ -10,5 +10,10 @@
     "APP_SECRET": "DeLonghiComfort2-Yg4miiqiNcf0Or-EhJwRh7ACfBY",
     "API_URL": "https://ads-eu.aylanetworks.com/apiv1",
     "OAUTH_URL": "https://user-field-eu.aylanetworks.com"
+  },
+  "USER_AGENT": {
+    "TOKEN": "DeLonghiComfort/3 CFNetwork/1568.300.101 Darwin/24.2.0",
+    "BROWSER": "Mozilla/5.0 (iPhone; CPU iPhone OS 13_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/79.0.3945.73 Mobile/15E148 Safari/604.1",
+    "API": "datatransport/3.1.2 android/"
   }
 }

--- a/cremalink/resources/lang.py
+++ b/cremalink/resources/lang.py
@@ -1,0 +1,28 @@
+"""
+This module provides a function to load the language configuration from the
+embedded `lang.json` resource file.
+"""
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from importlib import resources
+from typing import Any
+
+
+@lru_cache
+def load_lang_config() -> dict[str, Any]:
+    """
+    Loads the language configuration from the `lang.json` resource file.
+
+    This function uses `importlib.resources` to access the JSON file.
+
+    The `@lru_cache` decorator memoizes the result, so the file is only read
+    and parsed once, improving performance on subsequent calls.
+
+    Returns:
+        A dictionary containing the language configuration data.
+    """
+    resource = resources.files("cremalink.resources").joinpath("lang.json")
+    with resource.open("r", encoding="utf-8") as f:
+        return json.load(f)

--- a/cremalink/transports/cloud/transport.py
+++ b/cremalink/transports/cloud/transport.py
@@ -13,9 +13,6 @@ from cremalink.parsing.monitor.decode import build_monitor_snapshot
 from cremalink.transports.base import DeviceTransport
 from cremalink.resources import load_api_config
 
-API_USER_AGENT = "datatransport/3.1.2 android/"
-TOKEN_USER_AGENT = "DeLonghiComfort/3 CFNetwork/1568.300.101 Darwin/24.2.0"
-
 
 class CloudTransport(DeviceTransport):
     """
@@ -38,6 +35,8 @@ class CloudTransport(DeviceTransport):
         self.api_conf = load_api_config()
         self.gigya_api = self.api_conf.get("GIGYA")
         self.ayla_api = self.api_conf.get("AYLA")
+
+        self.api_agent = self.api_conf["USER_AGENT"]["API"]
 
         self.dsn = dsn
         self.access_token = access_token
@@ -71,7 +70,7 @@ class CloudTransport(DeviceTransport):
         response = requests.get(
             url=f"{self.ayla_api.get('API_URL')}/dsns/{self.dsn}{path}",
             headers={
-                "User-Agent": API_USER_AGENT,
+                "User-Agent": self.api_agent,
                 "Authorization": f"auth_token {self.access_token}",
                 "Accept": "application/json",
             },
@@ -84,7 +83,7 @@ class CloudTransport(DeviceTransport):
         response = requests.get(
             url=f"{self.ayla_api.get('API_URL')}/devices/{self.id}{path}",
             headers={
-                "User-Agent": API_USER_AGENT,
+                "User-Agent": self.api_agent,
                 "Authorization": f"auth_token {self.access_token}",
                 "Accept": "application/json",
             },
@@ -97,7 +96,7 @@ class CloudTransport(DeviceTransport):
         response = requests.post(
             url=f"{self.ayla_api.get('API_URL')}/dsns/{self.dsn}{path}",
             headers={
-                "User-Agent": API_USER_AGENT,
+                "User-Agent": self.api_agent,
                 "Authorization": f"auth_token {self.access_token}",
                 "Accept": "application/json",
                 "Content-Type": "application/json",


### PR DESCRIPTION
- Add `cremalink/clients/auth.py` to handle the Gigya/Ayla multi-step cloud authentication flow.
- Move hardcoded user agents from `cremalink/clients/cloud.py` and `cremalink/transports/cloud/transport.py` to `cremalink/resources/api_config.json`.
- Create `cremalink/resources/lang.py` with a utility to load language configurations.
- Add return type hints to `get_device` in the cloud client.