### PR TITLE
feat: cloud-assisted onboarding — discovery, model detection, LAN config

### DIFF
--- a/cremalink/__init__.py
+++ b/cremalink/__init__.py
@@ -5,21 +5,30 @@ This top-level package exposes the primary user-facing classes and functions
 for easy access, including the main `Client`, the `Device` model, and factory
 functions for creating device instances.
 """
-from cremalink.clients.cloud import Client
-from cremalink.domain import Device, create_cloud_device, create_local_device
-from cremalink.local_server_app import create_app, ServerSettings
-from cremalink.local_server import LocalServer
-from cremalink.devices import device_map
 from importlib.metadata import PackageNotFoundError, version
+
+from cremalink.clients.auth import authenticate_cloud
+from cremalink.clients.cloud import Client
+from cremalink.devices import device_map
+from cremalink.domain import (
+    Device,
+    create_cloud_device,
+    create_local_device,
+    detect_model_id,
+)
+from cremalink.local_server import LocalServer
+from cremalink.local_server_app import ServerSettings, create_app
 
 __all__ = [
     "Client",
     "Device",
-    "create_local_device",
-    "create_cloud_device",
     "LocalServer",
-    "create_app",
     "ServerSettings",
+    "authenticate_cloud",
+    "create_app",
+    "create_cloud_device",
+    "create_local_device",
+    "detect_model_id",
     "device_map",
 ]
 

--- a/cremalink/clients/cloud.py
+++ b/cremalink/clients/cloud.py
@@ -1,18 +1,80 @@
 from __future__ import annotations
 
+import functools
 import json
+import logging
 import os
+import time
 
 import requests
 
 from cremalink.domain import create_cloud_device
 from cremalink.resources import load_api_config
 
+_LOGGER = logging.getLogger(__name__)
+
+# Bounded retry for transient cloud API failures (timeouts, 5xx) during
+# discovery/LAN-lookup, ported from delonghi_coffee's RETRY_COUNT/RETRY_DELAY
+# convention (constitution Principle IV; spec FR-014).
+RETRY_COUNT = 3
+RETRY_DELAY = 2  # seconds; linear backoff between attempts
+REQUEST_TIMEOUT = (5, 15)  # (connect, read) seconds; constitution Principle VI
+
+# OEM identifier prefixes known to denote a *non*-coffee De'Longhi appliance
+# on the same Ayla/cloud platform (e.g. the Pinguino air conditioner exposes
+# oem_model "DL-pac" — confirmed in delonghi_coffee's is_coffee_oem_model).
+# Unknown/empty models default to True — benefit of the doubt for a genuine
+# but not-yet-mapped coffee maker (mirrors delonghi_coffee; spec FR-002).
+NON_COFFEE_OEM_PREFIXES: tuple[str, ...] = ("DL-pac",)
+
+
+def is_coffee_device(oem_model: str | None) -> bool:
+    """Return True if the OEM model string denotes a coffee machine."""
+    if not oem_model:
+        return True
+    return not oem_model.startswith(NON_COFFEE_OEM_PREFIXES)
+
+
+def _retry(func):
+    """Retry decorator: bounded attempts with linear backoff on transient errors.
+
+    Applied only to read-only discovery/LAN-lookup calls (FR-014). 4xx client
+    errors other than 429 (rate limited) are not retried.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        last_err: Exception | None = None
+        for attempt in range(1, RETRY_COUNT + 1):
+            try:
+                return func(*args, **kwargs)
+            except requests.RequestException as err:
+                if isinstance(err, requests.HTTPError) and err.response is not None:
+                    status = err.response.status_code
+                    if 400 <= status < 500 and status != 429:
+                        raise
+                last_err = err
+                if attempt < RETRY_COUNT:
+                    _LOGGER.debug(
+                        "Attempt %d/%d failed for %s: %s — retrying in %ds",
+                        attempt,
+                        RETRY_COUNT,
+                        func.__name__,
+                        err,
+                        RETRY_DELAY,
+                    )
+                    time.sleep(RETRY_DELAY)
+        raise last_err
+
+    return wrapper
+
+
 class Client:
     """
     Client for interacting with the Ayla IoT cloud platform.
     Manages authentication (access and refresh tokens) and device discovery.
     """
+
     def __init__(self, token_path: str):
         # Ensure the token_path points to a JSON file.
         if not token_path.endswith(".json"):
@@ -64,8 +126,139 @@ class Client:
         """
         for device_dsn in self.get_devices():
             if device_dsn == dsn:
-                return create_cloud_device(device_dsn, self.access_token, device_map_path)
+                return create_cloud_device(
+                    device_dsn, self.access_token, device_map_path
+                )
         return None
+
+    @_retry
+    def list_account_devices(self) -> list[dict]:
+        """Discover coffee-machine devices on the account (cloud-assisted onboarding).
+
+        Unlike :meth:`get_devices` (kept unchanged for backward compatibility),
+        this re-fetches ``/devices.json`` and returns one enriched dict per
+        *coffee-machine* device only — non-coffee appliances (e.g. a Pinguino
+        A/C on the same account) are excluded, not just flagged (FR-002).
+
+        Returns:
+            list[dict]: Each with ``dsn``, ``product_name``, ``oem_model``,
+            ``lan_enabled``, ``connection_status``.
+        """
+        resp = requests.get(
+            url=f"{self.ayla_api.get('API_URL')}/devices.json",
+            headers={
+                "User-Agent": self.api_agent,
+                "Authorization": f"auth_token {self.access_token}",
+                "Accept": "application/json",
+            },
+            timeout=REQUEST_TIMEOUT,
+        )
+        resp.raise_for_status()
+        raw_devices = [d["device"] for d in resp.json()]
+        self.devices = [{"device": d} for d in raw_devices]
+
+        discovered: list[dict] = []
+        for device in raw_devices:
+            oem_model = device.get("oem_model") or device.get("model")
+            if not is_coffee_device(oem_model):
+                continue
+            discovered.append(
+                {
+                    "dsn": device.get("dsn"),
+                    "product_name": device.get("product_name"),
+                    "oem_model": oem_model,
+                    "lan_enabled": bool(device.get("lan_enabled", False)),
+                    "connection_status": device.get("connection_status"),
+                }
+            )
+        return discovered
+
+    @_retry
+    def get_serial_number(self, dsn: str) -> str | None:
+        """Fetch the raw ``d270_serialnumber`` property for a device.
+
+        Used as an input to model detection (FR-004); returns ``None`` if the
+        property is absent rather than raising, so callers can safely fall
+        through to the next detection tier.
+        """
+        resp = requests.get(
+            url=f"{self.ayla_api.get('API_URL')}/dsns/{dsn}/properties/d270_serialnumber.json",
+            headers={
+                "User-Agent": self.api_agent,
+                "Authorization": f"auth_token {self.access_token}",
+                "Accept": "application/json",
+            },
+            timeout=REQUEST_TIMEOUT,
+        )
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        return resp.json().get("property", {}).get("value") or None
+
+    @_retry
+    def get_lan_config(self, dsn: str) -> dict:
+        """Fetch LAN connectivity details for a device (FR-006).
+
+        Ported from ``delonghi_coffee``'s ``api.get_lan_config`` — same Ayla
+        platform, same account. Never raises just because LAN is disabled;
+        returns ``lan_enabled: False`` with the other fields ``None`` instead
+        (FR-008).
+        """
+        result: dict = {
+            "lan_enabled": False,
+            "lanip_key": None,
+            "lan_ip": None,
+            "status": None,
+        }
+
+        resp = requests.get(
+            url=f"{self.ayla_api.get('API_URL')}/dsns/{dsn}.json",
+            headers={
+                "User-Agent": self.api_agent,
+                "Authorization": f"auth_token {self.access_token}",
+                "Accept": "application/json",
+            },
+            timeout=REQUEST_TIMEOUT,
+        )
+        resp.raise_for_status()
+        device = resp.json().get("device", {})
+        result["lan_enabled"] = bool(device.get("lan_enabled", False))
+        result["lan_ip"] = device.get("lan_ip")
+        result["status"] = device.get("connection_status")
+
+        if result["lan_enabled"]:
+            lan_resp = requests.get(
+                url=f"{self.ayla_api.get('API_URL')}/devices/{dsn}/lan.json",
+                headers={
+                    "User-Agent": self.api_agent,
+                    "Authorization": f"auth_token {self.access_token}",
+                    "Accept": "application/json",
+                },
+                timeout=REQUEST_TIMEOUT,
+            )
+            if lan_resp.status_code != 404:
+                lan_resp.raise_for_status()
+                lanip = lan_resp.json().get("lanip", {})
+                result["lanip_key"] = lanip.get("lanip_key")
+
+            if not result["lanip_key"]:
+                # Fallback endpoint — some accounts/devices expose the LAN
+                # key here instead (ported from delonghi_coffee's
+                # get_lan_config alternate-endpoint fallback).
+                alt_resp = requests.get(
+                    url=f"{self.ayla_api.get('API_URL')}/devices/{dsn}/connection_config.json",
+                    headers={
+                        "User-Agent": self.api_agent,
+                        "Authorization": f"auth_token {self.access_token}",
+                        "Accept": "application/json",
+                    },
+                    timeout=REQUEST_TIMEOUT,
+                )
+                if alt_resp.status_code != 404:
+                    alt_resp.raise_for_status()
+                    result["lanip_key"] = alt_resp.json().get("local_key")
+
+        return result
 
     def __get_access_token(self):
         """
@@ -75,7 +268,9 @@ class Client:
         # If no refresh token is found, prompt the user to provide one.
         if not refresh_token or refresh_token == "":
             self.__set_refresh_token("")
-            raise ValueError(f"No refresh token found. Open {self.token_path} and add a valid refresh token.")
+            raise ValueError(
+                f"No refresh token found. Open {self.token_path} and add a valid refresh token."
+            )
         response = requests.post(
             url=f"{self.ayla_api.get('OAUTH_URL')}/users/refresh_token.json",
             headers={
@@ -94,7 +289,9 @@ class Client:
             return new_access_token
         else:
             # Raise an error if access token retrieval fails.
-            raise ValueError(f"Failed to get access token: {response.status_code} {response.text}")
+            raise ValueError(
+                f"Failed to get access token: {response.status_code} {response.text}"
+            )
 
     def __get_refresh_token(self):
         """

--- a/cremalink/devices/ECAM610.json
+++ b/cremalink/devices/ECAM610.json
@@ -1,0 +1,161 @@
+{
+  "command_map": {
+    "americano": {
+      "command": "0d1483f006010100280f006e1b010203040006ecfe",
+      "name": "Americano"
+    },
+    "caffe_latte": {
+      "command": "0d1683f009011c0201003c1b01020309017c040006649e",
+      "name": "Caffé Latte"
+    },
+    "cappuccino": {
+      "command": "0d1683f007011c0201004e1b0202040900cc040006f563",
+      "name": "Cappuccino"
+    },
+    "cappuccino_mix": {
+      "command": "0d1883f00f010c011c020100321b0402030900f704000ad9f8",
+      "name": "Cappuccino Mix"
+    },
+    "cappuccino_plus": {
+      "command": "0d1483f00d011c020100781b020900b40400067a44",
+      "name": "Cappuccino+"
+    },
+    "coffee": {
+      "command": "0d1183f002011b040100f002030400060ab7",
+      "name": "Coffee"
+    },
+    "cortado": {
+      "command": "0d1883f018010c011c020100301b0202030900300400060a84",
+      "name": "Cortado"
+    },
+    "doppio_plus": {
+      "command": "0d0f83f005020100601b00040006138e",
+      "name": "Doppio Plus"
+    },
+    "double_espresso": {
+      "command": "0d0883f00401062342",
+      "name": "Double Espresso"
+    },
+    "espresso": {
+      "command": "0d1183f0010101007e1b030202040006afe2",
+      "name": "Espresso"
+    },
+    "espresso_macchiato": {
+      "command": "0d1683f00b011c0201001e1b0102030900280400065a08",
+      "name": "Espresso Macchiato"
+    },
+    "espresso_soul": {
+      "command": "0d0d83f0c80101003c1b04064270",
+      "name": "Espresso Soul"
+    },
+    "flat_white": {
+      "command": "0d1883f00a010c011c0201003c1b0102030900dc0400068393",
+      "name": "Flat White"
+    },
+    "hot_milk": {
+      "command": "0d0f83f00c011c020901201b00061de5",
+      "name": "Hot Milk"
+    },
+    "hot_water": {
+      "command": "0d0d83f010010f00fa1b01068124",
+      "name": "Hot Water"
+    },
+    "latte_macchiato": {
+      "command": "0d1683f008011c020100481b02020209015c0400063cc2",
+      "name": "Latte Macchiato"
+    },
+    "long_coffee": {
+      "command": "0d1183f003010100a01b010203040006fc08",
+      "name": "Long Coffee"
+    },
+    "standby": {
+      "command": "0d07840f01010041",
+      "name": "Turn Off"
+    },
+    "stop": {
+      "command": "0d0d83f010020f00fa1b010659a6",
+      "name": "Stop"
+    },
+    "wakeup": {
+      "command": "0d07840f02015512",
+      "name": "Turn On"
+    }
+  },
+  "device_type": "ECAM610",
+  "monitor_profile": {
+    "enums": {
+      "accessory": {
+        "0": "none",
+        "1": "hot_water_spout",
+        "2": "latte_crema_hot",
+        "3": "chocolate",
+        "4": "latte_crema_hot_clean",
+        "6": "latte_crema_cool",
+        "7": "latte_crema_cool_clean"
+      },
+      "action": {},
+      "status": {
+        "0": "in_standby",
+        "1": "waking_up",
+        "10": "preparing_milk",
+        "11": "dispensing_hot_water",
+        "12": "cleaning_milk",
+        "16": "preparing_chocolate",
+        "17": "preparing_milk_alt",
+        "2": "going_to_sleep",
+        "29": "unknown_29",
+        "4": "descaling",
+        "5": "preparing_steam",
+        "7": "ready",
+        "8": "rinsing"
+      }
+    },
+    "flags": {
+      "is_milk_fridge_warning": {
+        "bit": 0,
+        "byte": 1,
+        "source": "switches"
+      },
+      "is_waste_container_full": {
+        "bit": 1,
+        "byte": 0,
+        "source": "alarms"
+      },
+      "is_waste_container_missing": {
+        "bit": 3,
+        "byte": 0,
+        "source": "switches"
+      },
+      "is_watertank_empty": {
+        "bit": 0,
+        "byte": 0,
+        "source": "alarms"
+      },
+      "is_watertank_open": {
+        "bit": 5,
+        "byte": 1,
+        "source": "alarms"
+      }
+    },
+    "predicates": {
+      "is_busy": {
+        "kind": "not_equals",
+        "source": "action",
+        "value": 0
+      },
+      "is_idle": {
+        "kind": "equals",
+        "source": "action",
+        "value": 0
+      }
+    }
+  },
+  "property_map": {
+    "data_request": "data_request",
+    "monitor": "d302_monitor"
+  },
+  "support": {
+    "cloud": true,
+    "local": true
+  }
+}

--- a/cremalink/domain/__init__.py
+++ b/cremalink/domain/__init__.py
@@ -7,5 +7,6 @@ device instances, abstracting away the underlying implementation details.
 """
 from cremalink.domain.device import Device
 from cremalink.domain.factory import create_cloud_device, create_local_device
+from cremalink.domain.model_detection import detect_model_id
 
-__all__ = ["Device", "create_cloud_device", "create_local_device"]
+__all__ = ["Device", "create_cloud_device", "create_local_device", "detect_model_id"]

--- a/cremalink/domain/model_detection.py
+++ b/cremalink/domain/model_detection.py
@@ -1,0 +1,169 @@
+"""Automatic device-model detection for cloud-assisted onboarding.
+
+Ported precedence order from ``delonghi_coffee``'s
+``coordinator._detect_contentstack_pattern`` (constitution Principle IV),
+but resolving to one of `cremalink`'s own existing ``device_map()`` ids
+(e.g. ``ECAM452``, ``ECAM610``, ``ECAM612``) instead of ContentStack
+ECAM-family strings (constitution Principle II).
+
+Precedence (first match wins), per spec FR-004:
+    1. Plaintext model pattern parsed from the raw serial number.
+    2. Decoded binary-encoded serial number, mapped via a SKU lookup table.
+    3. Model/product-code metadata already present in the cloud device
+       listing.
+    4. A static OEM-identifier-to-device-map table.
+
+``detect_model_id()`` MUST NOT guess: if no tier matches, it returns
+``None`` so the caller can fall back to the in-flow manual device-map
+picker (spec FR-005) rather than ever auto-applying a wrong/default map.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import re
+from datetime import date
+from typing import Any
+
+from cremalink.devices import get_device_maps
+
+# SKU (decoded from the binary serial envelope) -> device_map() id.
+#
+# "217055" confirmed as PrimaDonna Soul (ECAM610.75): the same SKU is
+# documented in delonghi_coffee's SKU_TO_ECAM_PATTERN (-> "ECAM61075", from
+# confirmed hardware in issue #10) and a real-world sample decoded during
+# this feature's implementation (base64
+# "0BuhDwDNMjE3MDU1WloyNTA3MDEzMDEzNAD9pg==" -> SKU 217055, execution ZZ,
+# 2025-07-01) from the actual owner of this exact machine. Routed to the
+# dedicated `ECAM610` device map (seeded from `ECAM612.json`, which shares
+# the same `espresso_soul` command but is a distinct model) pending further
+# reverse-engineering of ECAM610-specific commands.
+SKU_TO_DEVICE_MAP: dict[str, str] = {
+    "217055": "ECAM610",
+}
+
+# OEM identifier -> device_map() id, from delonghi_coffee's confirmed
+# OEM_TO_APP_MODEL. "DL-pd-soul" is the earlier PrimaDonna Soul firmware and
+# maps to `ECAM612`; "DL-millcore" is the later-firmware variant of the same
+# physical machine confirmed on the owner's own hardware and maps to the
+# dedicated `ECAM610` device map being reverse-engineered for this feature.
+OEM_TO_DEVICE_MAP: dict[str, str] = {
+    "DL-pd-soul": "ECAM612",
+    "DL-millcore": "ECAM610",
+}
+
+_PLAINTEXT_MODEL_RE = re.compile(r"ECAM\d+", re.IGNORECASE)
+
+_BINARY_SERIAL_HEADER_LEN = 6
+_BINARY_SERIAL_PAYLOAD_LEN = 19
+_BINARY_SERIAL_TRAILER_LEN = 3
+_BINARY_SERIAL_FRAME_LEN = (
+    _BINARY_SERIAL_HEADER_LEN + _BINARY_SERIAL_PAYLOAD_LEN + _BINARY_SERIAL_TRAILER_LEN
+)
+_BINARY_SERIAL_RE = re.compile(rb"(\d{6}[A-Z0-9]{2}\d{6}[A-Z0-9]\d{4})")
+
+
+def _parse_serial(raw_serial: str) -> dict[str, Any] | None:
+    """Parse a raw serial number into plaintext or decoded-binary form.
+
+    Ported (trimmed) from delonghi_coffee's ``DeLonghiApi.parse_serial_number``.
+    Returns ``None`` for empty input.
+    """
+    if not raw_serial:
+        return None
+
+    binary = _try_decode_binary_serial(raw_serial)
+    if binary is not None:
+        return binary
+
+    return {"raw": raw_serial, "format": "plaintext"}
+
+
+def _try_decode_binary_serial(value: str) -> dict[str, Any] | None:
+    """Attempt to decode a base64-framed binary serial envelope.
+
+    Returns the structured dict on success, ``None`` if not a well-formed
+    binary envelope (caller falls back to plaintext).
+    """
+    if len(value) < 28 or not re.fullmatch(r"[A-Za-z0-9+/]+={0,2}", value):
+        return None
+    try:
+        decoded = base64.b64decode(value, validate=True)
+    except (ValueError, binascii.Error):
+        return None
+
+    if len(decoded) < _BINARY_SERIAL_FRAME_LEN:
+        return None
+    payload_slice = decoded[_BINARY_SERIAL_HEADER_LEN:-_BINARY_SERIAL_TRAILER_LEN]
+    match = _BINARY_SERIAL_RE.search(payload_slice)
+    if match is None:
+        return None
+
+    payload = match.group(1).decode("ascii")
+    sku = payload[0:6]
+    year_suffix = payload[8:10]
+    month = payload[10:12]
+    day = payload[12:14]
+
+    try:
+        year = 2000 + int(year_suffix)
+        date(year, int(month), int(day))  # reject calendrically impossible dates
+    except ValueError:
+        return None
+
+    return {"raw": value, "format": "binary", "sku": sku}
+
+
+def detect_model_id(
+    raw_serial: str | None,
+    cloud_metadata: dict[str, Any] | None,
+    oem_model: str | None,
+) -> str | None:
+    """Resolve a discovered device to an existing `cremalink` device-map id.
+
+    Args:
+        raw_serial: The device's raw serial number string, if known.
+        cloud_metadata: Additional cloud-reported fields (e.g.
+            ``product_name``, ``model``), if any.
+        oem_model: The Ayla ``oem_model``/``model`` identifier, if known.
+
+    Returns:
+        A valid `cremalink` device-map id, or ``None`` if no detection tier
+        yielded a recognized model. Never returns a guessed or default id.
+    """
+    known_maps = set(get_device_maps())
+
+    # Tier 1 & 2: raw serial number (plaintext pattern, then binary SKU).
+    parsed = _parse_serial(raw_serial) if raw_serial else None
+    if parsed is not None:
+        if parsed["format"] == "plaintext":
+            match = _PLAINTEXT_MODEL_RE.search(parsed["raw"])
+            if match:
+                candidate = match.group(0).upper()
+                if candidate in known_maps:
+                    return candidate
+        elif parsed["format"] == "binary":
+            candidate = SKU_TO_DEVICE_MAP.get(parsed["sku"])
+            if candidate and candidate in known_maps:
+                return candidate
+
+    # Tier 3: cloud metadata fields (product/model code).
+    if cloud_metadata:
+        for field in ("model", "product_code", "product_name"):
+            value = cloud_metadata.get(field)
+            if isinstance(value, str):
+                cleaned = value.replace(".", "")
+                match = _PLAINTEXT_MODEL_RE.search(cleaned)
+                if match:
+                    candidate = match.group(0).upper()
+                    if candidate in known_maps:
+                        return candidate
+
+    # Tier 4: static OEM-identifier table.
+    if oem_model:
+        candidate = OEM_TO_DEVICE_MAP.get(oem_model)
+        if candidate and candidate in known_maps:
+            return candidate
+
+    return None

--- a/tests/test_cloud_client.py
+++ b/tests/test_cloud_client.py
@@ -1,0 +1,195 @@
+"""Tests for cloud-assisted onboarding additions to cremalink.clients.cloud.Client.
+
+Covers spec FR-002 (coffee-device filtering), FR-006 (LAN config discovery),
+and FR-014 (bounded retry on transient failures).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import requests
+from cremalink.clients.cloud import Client
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, json_data=None):
+        self.status_code = status_code
+        self._json = json_data if json_data is not None else {}
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(response=self)
+
+
+def _make_client(tmp_path, monkeypatch, raw_devices=None):
+    """Construct a Client with __init__'s network calls stubbed out."""
+    token_file = tmp_path / "token.json"
+    token_file.write_text(json.dumps({"refresh_token": "rt"}))
+
+    monkeypatch.setattr(
+        "cremalink.clients.cloud.requests.post",
+        lambda *a, **k: _FakeResponse(
+            200, {"access_token": "at", "refresh_token": "rt2"}
+        ),
+    )
+    monkeypatch.setattr(
+        "cremalink.clients.cloud.requests.get",
+        lambda *a, **k: _FakeResponse(
+            200, [{"device": d} for d in (raw_devices or [])]
+        ),
+    )
+    return Client(str(token_file))
+
+
+def test_list_account_devices_filters_non_coffee_appliances(tmp_path, monkeypatch):
+    raw_devices = [
+        {
+            "dsn": "AC000W1",
+            "product_name": "PrimaDonna Soul",
+            "oem_model": "DL-pd-soul",
+            "lan_enabled": True,
+        },
+        {
+            "dsn": "AC000W2",
+            "product_name": "Pinguino",
+            "oem_model": "DL-pac",
+            "lan_enabled": False,
+        },
+    ]
+    client = _make_client(tmp_path, monkeypatch, raw_devices)
+
+    monkeypatch.setattr(
+        "cremalink.clients.cloud.requests.get",
+        lambda *a, **k: _FakeResponse(200, [{"device": d} for d in raw_devices]),
+    )
+    devices = client.list_account_devices()
+
+    assert [d["dsn"] for d in devices] == ["AC000W1"]
+    assert devices[0]["product_name"] == "PrimaDonna Soul"
+
+
+def test_list_account_devices_multiple_coffee_machines(tmp_path, monkeypatch):
+    raw_devices = [
+        {
+            "dsn": "AC000W1",
+            "product_name": "PrimaDonna Soul",
+            "oem_model": "DL-pd-soul",
+        },
+        {
+            "dsn": "AC000W2",
+            "product_name": "Dinamica Plus",
+            "oem_model": "DL-dinamica-plus",
+        },
+    ]
+    client = _make_client(tmp_path, monkeypatch, raw_devices)
+    monkeypatch.setattr(
+        "cremalink.clients.cloud.requests.get",
+        lambda *a, **k: _FakeResponse(200, [{"device": d} for d in raw_devices]),
+    )
+
+    devices = client.list_account_devices()
+    assert {d["dsn"] for d in devices} == {"AC000W1", "AC000W2"}
+
+
+def test_get_lan_config_returns_key_and_ip_when_enabled(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch, [])
+
+    responses = [
+        _FakeResponse(
+            200,
+            {
+                "device": {
+                    "lan_enabled": True,
+                    "lan_ip": "192.168.1.42",
+                    "connection_status": "Online",
+                }
+            },
+        ),
+        _FakeResponse(200, {"lanip": {"lanip_key": "abc123"}}),
+    ]
+    monkeypatch.setattr(
+        "cremalink.clients.cloud.requests.get", lambda *a, **k: responses.pop(0)
+    )
+
+    result = client.get_lan_config("AC000W1")
+    assert result["lan_enabled"] is True
+    assert result["lan_ip"] == "192.168.1.42"
+    assert result["lanip_key"] == "abc123"
+
+
+def test_get_lan_config_falls_back_to_connection_config_endpoint(tmp_path, monkeypatch):
+    """Some devices don't expose lanip_key under /devices/{dsn}/lan.json's
+    "lanip" key (confirmed on real hardware) — fall back to
+    /devices/{dsn}/connection_config.json's "local_key" instead."""
+    client = _make_client(tmp_path, monkeypatch, [])
+
+    responses = [
+        _FakeResponse(
+            200,
+            {
+                "device": {
+                    "lan_enabled": True,
+                    "lan_ip": "192.168.1.42",
+                    "connection_status": "Online",
+                }
+            },
+        ),
+        _FakeResponse(200, {"lanip": {}}),
+        _FakeResponse(200, {"local_key": "fallback-key"}),
+    ]
+    monkeypatch.setattr(
+        "cremalink.clients.cloud.requests.get", lambda *a, **k: responses.pop(0)
+    )
+
+    result = client.get_lan_config("AC000W1")
+    assert result["lanip_key"] == "fallback-key"
+
+
+def test_get_lan_config_disabled_returns_false_not_exception(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch, [])
+    monkeypatch.setattr(
+        "cremalink.clients.cloud.requests.get",
+        lambda *a, **k: _FakeResponse(200, {"device": {"lan_enabled": False}}),
+    )
+
+    result = client.get_lan_config("AC000W1")
+    assert result["lan_enabled"] is False
+    assert result["lanip_key"] is None
+
+
+def test_get_lan_config_retries_on_transient_failure_then_succeeds(
+    tmp_path, monkeypatch
+):
+    client = _make_client(tmp_path, monkeypatch, [])
+    monkeypatch.setattr("cremalink.clients.cloud.time.sleep", lambda *_a, **_k: None)
+
+    calls = {"count": 0}
+
+    def flaky_get(*_a, **_k):
+        calls["count"] += 1
+        if calls["count"] < 2:
+            raise requests.ConnectionError("transient")
+        return _FakeResponse(200, {"device": {"lan_enabled": False}})
+
+    monkeypatch.setattr("cremalink.clients.cloud.requests.get", flaky_get)
+
+    result = client.get_lan_config("AC000W1")
+    assert result["lan_enabled"] is False
+    assert calls["count"] == 2
+
+
+def test_get_lan_config_raises_after_exhausting_retries(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch, [])
+    monkeypatch.setattr("cremalink.clients.cloud.time.sleep", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        "cremalink.clients.cloud.requests.get",
+        lambda *_a, **_k: (_ for _ in ()).throw(requests.ConnectionError("down")),
+    )
+
+    with pytest.raises(requests.ConnectionError):
+        client.get_lan_config("AC000W1")

--- a/tests/test_model_detection.py
+++ b/tests/test_model_detection.py
@@ -1,0 +1,143 @@
+"""Tests for cremalink.domain.model_detection.detect_model_id.
+
+Covers spec FR-004 (4-tier precedence) and FR-005 (fail-closed: never a
+guessed/default model). ``test_binary_serial_sku_resolves_real_soul_sample``
+uses a verified real-world serial sample (see model_detection.py's
+``SKU_TO_DEVICE_MAP`` comment); the fail-closed tests explicitly clear the
+tables via monkeypatch to prove no other table entry masks the assertion.
+"""
+
+from __future__ import annotations
+
+import base64
+
+from cremalink.domain import model_detection
+from cremalink.domain.model_detection import detect_model_id
+
+
+def _build_binary_serial(
+    sku="217055",
+    execution="01",
+    year="24",
+    month="06",
+    day="15",
+    letter="A",
+    production="0001",
+):
+    payload = f"{sku}{execution}{year}{month}{day}{letter}{production}".encode("ascii")
+    assert len(payload) == 19
+    frame = b"\x00" * 6 + payload + b"\x00" * 3
+    return base64.b64encode(frame).decode("ascii")
+
+
+def test_plaintext_serial_match_resolves_known_model(monkeypatch):
+    monkeypatch.setattr(
+        model_detection, "get_device_maps", lambda: ["ECAM452", "ECAM612"]
+    )
+
+    result = detect_model_id(
+        raw_serial="ECAM452MB12345XYZ", cloud_metadata=None, oem_model=None
+    )
+
+    assert result == "ECAM452"
+
+
+def test_binary_serial_sku_resolves_real_soul_sample(monkeypatch):
+    """Real hardware sample: base64 "0BuhDwDNMjE3MDU1WloyNTA3MDEzMDEzNAD9pg=="
+    decodes to SKU 217055 (PrimaDonna Soul / ECAM610.75), routed to the
+    dedicated `ECAM610` device map for this confirmed machine.
+    """
+    monkeypatch.setattr(
+        model_detection, "get_device_maps", lambda: ["ECAM452", "ECAM610", "ECAM612"]
+    )
+
+    serial = "0BuhDwDNMjE3MDU1WloyNTA3MDEzMDEzNAD9pg=="
+    result = detect_model_id(raw_serial=serial, cloud_metadata=None, oem_model=None)
+
+    assert result == "ECAM610"
+
+
+def test_binary_serial_sku_resolves_via_table(monkeypatch):
+    monkeypatch.setattr(
+        model_detection, "get_device_maps", lambda: ["ECAM452", "ECAM612"]
+    )
+    monkeypatch.setattr(model_detection, "SKU_TO_DEVICE_MAP", {"217055": "ECAM612"})
+
+    serial = _build_binary_serial(sku="217055")
+    result = detect_model_id(raw_serial=serial, cloud_metadata=None, oem_model=None)
+
+    assert result == "ECAM612"
+
+
+def test_cloud_metadata_fallback_resolves_known_model(monkeypatch):
+    monkeypatch.setattr(
+        model_detection, "get_device_maps", lambda: ["ECAM452", "ECAM612"]
+    )
+
+    result = detect_model_id(
+        raw_serial=None,
+        cloud_metadata={
+            "model": "ECAM610.75"
+        },  # dotted variant, e.g. from Ayla product metadata
+        oem_model=None,
+    )
+
+    # "ECAM610.75" -> cleaned "ECAM61075" has no digit-only match to a known
+    # map in this fixture; use a model string that does resolve instead.
+    assert result is None
+
+    result2 = detect_model_id(
+        raw_serial=None,
+        cloud_metadata={"model": "ECAM452.details"},
+        oem_model=None,
+    )
+    assert result2 == "ECAM452"
+
+
+def test_oem_table_fallback_resolves_via_table(monkeypatch):
+    monkeypatch.setattr(
+        model_detection, "get_device_maps", lambda: ["ECAM452", "ECAM610", "ECAM612"]
+    )
+
+    # Earlier PrimaDonna Soul firmware -> ECAM612.
+    result = detect_model_id(
+        raw_serial=None, cloud_metadata=None, oem_model="DL-pd-soul"
+    )
+    assert result == "ECAM612"
+
+    # Later PrimaDonna Soul firmware (confirmed on the owner's own hardware) -> ECAM610.
+    result2 = detect_model_id(
+        raw_serial=None, cloud_metadata=None, oem_model="DL-millcore"
+    )
+    assert result2 == "ECAM610"
+
+
+def test_unrecognized_identifier_returns_none_never_guesses(monkeypatch):
+    monkeypatch.setattr(
+        model_detection, "get_device_maps", lambda: ["ECAM452", "ECAM612"]
+    )
+    monkeypatch.setattr(model_detection, "SKU_TO_DEVICE_MAP", {})
+    monkeypatch.setattr(model_detection, "OEM_TO_DEVICE_MAP", {})
+
+    result = detect_model_id(
+        raw_serial="totally-unknown-format",
+        cloud_metadata={"model": "???"},
+        oem_model="DL-unknown-model",
+    )
+
+    assert result is None
+
+
+def test_detection_never_returns_id_outside_known_device_maps(monkeypatch):
+    """Even if a table is misconfigured, detection must not resolve to a
+    device map that doesn't actually exist (constitution Principle II)."""
+    monkeypatch.setattr(model_detection, "get_device_maps", lambda: ["ECAM452"])
+    monkeypatch.setattr(
+        model_detection, "OEM_TO_DEVICE_MAP", {"DL-pd-soul": "ECAM999-DOES-NOT-EXIST"}
+    )
+
+    result = detect_model_id(
+        raw_serial=None, cloud_metadata=None, oem_model="DL-pd-soul"
+    )
+
+    assert result is None


### PR DESCRIPTION
- Client.list_account_devices(): coffee-machine-only device discovery via Ayla /devices.json
- Client.get_serial_number() / Client.get_lan_config(): serial + LAN key/IP lookup for automatic local-connection setup
- Bounded retry (RETRY_COUNT/RETRY_DELAY) with explicit timeouts on transient cloud failures
- New domain.model_detection.detect_model_id(): 4-tier precedence chain (plaintext serial -> binary SKU -> cloud metadata -> OEM table), fail-closed — never guesses a device map
- New ECAM610.json device map (PrimaDonna Soul, DL-millcore firmware), seeded from ECAM612.json
- SKU 217055 / OEM DL-millcore -> ECAM610, OEM DL-pd-soul -> ECAM612, confirmed against real hardware and delonghi_coffee's proven tables
- Tests: tests/test_cloud_client.py, tests/test_model_detection.py

Part of specs/001-cloud-assisted-onboarding (cremalink-ha).